### PR TITLE
port to latest firmware

### DIFF
--- a/heap_defence.c
+++ b/heap_defence.c
@@ -82,6 +82,7 @@ typedef struct {
 static const uint8_t ROW_BYTE_SIZE = sizeof(Box) * X_FIELD_SIZE;
 
 typedef struct {
+    FuriMutex* mutex;
     Box** field;
     Person* person;
     Animations animation;
@@ -114,6 +115,8 @@ static void game_reset_field_and_player(GameState* game) {
 static GameState* allocGameState() {
     GameState* game = malloc(sizeof(GameState));
 
+    game->mutex = furi_mutex_alloc(FuriMutexTypeNormal);
+
     game->person = malloc(sizeof(Person));
 
     game->field = malloc(Y_FIELD_SIZE * sizeof(Box*));
@@ -129,6 +132,7 @@ static GameState* allocGameState() {
 
 static void game_destroy(GameState* game) {
     furi_assert(game);
+    furi_mutex_free(game->mutex);
     free(game->field[0]);
     free(game->field);
     free(game);
@@ -430,17 +434,18 @@ static void draw_box(Canvas* canvas, Box* box, int x, int y) {
     }
 }
 
-static void heap_defense_render_callback(Canvas* const canvas, void* mutex) {
-    furi_assert(mutex);
+static void heap_defense_render_callback(Canvas* const canvas, void* arg) {
+    const GameState* game = arg;
+    furi_assert(game);
 
-    const GameState* game = acquire_mutex((ValueMutex*)mutex, 25);
+    furi_mutex_acquire(game->mutex, 25);
 
     ///Draw GameOver or Pause
     if(!(game->game_status & GameStatusInProgress)) {
         FURI_LOG_W(TAG, "[DAED_DRAW]func: [%s] line: %d ", __FUNCTION__, __LINE__);
 
         canvas_draw_icon_animation(canvas, 0, 0, animations[game->animation]);
-        release_mutex((ValueMutex*)mutex, game);
+        furi_mutex_release(game->mutex);
         return;
     }
 
@@ -480,7 +485,7 @@ static void heap_defense_render_callback(Canvas* const canvas, void* mutex) {
         }
     }
 
-    release_mutex((ValueMutex*)mutex, game);
+    furi_mutex_release(game->mutex);
 }
 
 static void heap_defense_input_callback(InputEvent* input_event, FuriMessageQueue* event_queue) {
@@ -494,7 +499,7 @@ static void heap_defense_input_callback(InputEvent* input_event, FuriMessageQueu
 static void heap_defense_timer_callback(FuriMessageQueue* event_queue) {
     furi_assert(event_queue);
 
-    GameEvent event = {.type = EventGameTick, .input = {0}};
+    GameEvent event = {.type = EventGameTick};
     furi_message_queue_put(event_queue, &event, 0);
 }
 
@@ -506,15 +511,9 @@ int32_t heap_defence_app(void* p) {
     FuriMessageQueue* event_queue = furi_message_queue_alloc(8, sizeof(GameEvent));
     GameState* game = allocGameState();
 
-    ValueMutex state_mutex;
-    if(!init_mutex(&state_mutex, game, sizeof(GameState))) {
-        game_destroy(game);
-        return 1;
-    }
-
     assets_load();
     ViewPort* view_port = view_port_alloc();
-    view_port_draw_callback_set(view_port, heap_defense_render_callback, &state_mutex);
+    view_port_draw_callback_set(view_port, heap_defense_render_callback, game);
     view_port_input_callback_set(view_port, heap_defense_input_callback, event_queue);
 
     FuriTimer* timer =
@@ -537,7 +536,7 @@ int32_t heap_defence_app(void* p) {
             continue;
         }
 
-        game = (GameState*)acquire_mutex_block(&state_mutex);
+        furi_mutex_acquire(game->mutex, UINT32_MAX);
 
         //unset vibration
         if(game->game_status & GameStatusVibro) {
@@ -574,7 +573,7 @@ int32_t heap_defence_app(void* p) {
                 notification_message(notification, &sequence_error);
             }
         }
-        release_mutex(&state_mutex, game);
+        furi_mutex_release(game->mutex);
         view_port_update(view_port);
     }
 
@@ -586,7 +585,6 @@ int32_t heap_defence_app(void* p) {
     furi_record_close("notification");
     furi_message_queue_free(event_queue);
     assets_clear();
-    delete_mutex(&state_mutex);
     game_destroy(game);
 
     return 0;


### PR DESCRIPTION
`ValueMutex` [was removed](https://github.com/flipperdevices/flipperzero-firmware/pull/2467) from API starting from [`0.79.1`](https://github.com/flipperdevices/flipperzero-firmware/releases/tag/0.79.1). This PR replaces its usage with `FuriMutex`.

This PR also fixes a compilation error related to the insides of `InputEvent` by leaving it uninitialized in the initialization of `GameEvent`.